### PR TITLE
Add reconnect and every config attributes

### DIFF
--- a/lib/Message/Passing/Redis/ConnectionManager.pm
+++ b/lib/Message/Passing/Redis/ConnectionManager.pm
@@ -1,5 +1,6 @@
 package Message::Passing::Redis::ConnectionManager;
 use Moo;
+use MooX::Types::MooseLike::Base qw/ Int /;
 use Scalar::Util qw/ weaken /;
 use Redis;
 use AnyEvent;
@@ -12,12 +13,26 @@ with qw/
 
 sub _default_port { 6379 }
 
+has reconnect => (
+    isa => Int,
+    is  => 'ro',
+    default => sub { 0 },
+);
+has every => (
+    isa => Int,
+    is => 'ro',
+    default => sub { 0 },
+);
 sub _build_connection {
     my $self = shift;
     weaken($self);
     my $client = Redis->new(
         encoding => undef,
         server => sprintf("%s:%s", $self->hostname, $self->port),
+        ($self->reconnect && $self->every
+            ? (reconnect => $self->reconnect, every => $self->every)
+            : ()
+        ),
     );
     # Delay calling set_connected till we've finished building the client
     my $i; $i = AnyEvent->idle(cb => sub {

--- a/lib/Message/Passing/Redis/Role/HasAConnection.pm
+++ b/lib/Message/Passing/Redis/Role/HasAConnection.pm
@@ -1,19 +1,30 @@
 package Message::Passing::Redis::Role::HasAConnection;
 use Moo::Role;
 use Message::Passing::Redis::ConnectionManager;
+use MooX::Types::MooseLike::Base qw/ Int /;
 use namespace::clean -except => 'meta';
 
 with qw/
     Message::Passing::Role::HasAConnection
     Message::Passing::Role::HasHostnameAndPort
 /;
-
+has reconnect => (
+    isa => Int,
+    is  => 'ro',
+    default => sub { 0 },
+);
+has every => (
+    isa => Int,
+    is => 'ro',
+    default => sub { 0 },
+);
 sub _default_port { 6379 }
 
+use Data::Printer;
 sub _build_connection_manager {
     my $self = shift;
     Message::Passing::Redis::ConnectionManager->new(map { $_ => $self->$_() }
-        qw/ hostname port /
+        qw/ hostname port reconnect every/
     );
 }
 


### PR DESCRIPTION
We add them to the connection manager and the connection role, so we can pass
them to Redis when we connect. It could perhaps be a good idea to also allow
setting `conservative_reconnect`, but we are only dealing with messages here,
so I don't need it for my environment at least.

The rationale for this is that if the redis-server dies, we never try to reconnect (at least it didn't in my limited testing), but setting these options ensures we do. The default is to not enable this, to behave like the old code did.